### PR TITLE
Getting wrong return type from objectsOfClassNamed:usingSortDescriptors:

### DIFF
--- a/Classes/Public/NSFNanoStore.m
+++ b/Classes/Public/NSFNanoStore.m
@@ -444,8 +444,11 @@
     search.sort = theSortDescriptors;
     
     NSString *theSQLStatement = [NSString stringWithFormat:@"SELECT NSFKey, NSFPlist, NSFObjectClass FROM NSFKeys WHERE NSFObjectClass = \"%@\"", theClassName];
-        
-    return [search executeSQL:theSQLStatement returnType:NSFReturnObjects error:nil];
+    
+    if (nil == theSortDescriptors) 
+        return [[search executeSQL:theSQLStatement returnType:NSFReturnObjects error:nil] allValues];
+    else
+        return [search executeSQL:theSQLStatement returnType:NSFReturnObjects error:nil];
 }
 
 #pragma mark Database Optimizations and Maintenance


### PR DESCRIPTION
- (NSArray *)objectsOfClassNamed:(NSString *)theClassName usingSortDescriptors:(NSArray *)theSortDescriptors is returning NSDictionary if theSortDescriptors is nil. 

Small change to ensure return object is always an NSArray.
