### PR TITLE
Empty search expressions should return all objects, not none

### DIFF
--- a/Classes/Public/NSFNanoSearch.m
+++ b/Classes/Public/NSFNanoSearch.m
@@ -610,22 +610,30 @@
     NSMutableString *parentheses = [NSMutableString new];
     NSFReturnType returnType = returnedObjectType;
 
-    for (i = 0; i < count; i++) {
-        NSFNanoExpression *expression = [someExpressions objectAtIndex:i];
-        NSMutableString *theSQL = nil;;
-        
+    if (count == 0) {
         if (NSFReturnObjects == returnType) {
-            theSQL = [[NSMutableString alloc]initWithFormat:@"SELECT NSFKEY FROM NSFValues WHERE %@", [expression description]];
+            [sqlComponents addObject:@"SELECT NSFKEY FROM NSFValues"];
         } else {
-            theSQL = [[NSMutableString alloc]initWithFormat:@"SELECT DISTINCT (NSFKEY) FROM NSFValues WHERE %@", [expression description]];
+            [sqlComponents addObject:@"SELECT DISTINCT (NSFKEY) FROM NSFValues"];
         }
-        
-        if ((count > 1) && (i < count-1)) {
-            [theSQL appendString:@" AND NSFKEY IN ("];
-            [parentheses appendString:@")"];
+    } else {
+        for (i = 0; i < count; i++) {
+            NSFNanoExpression *expression = [someExpressions objectAtIndex:i];
+            NSMutableString *theSQL = nil;;
+            
+            if (NSFReturnObjects == returnType) {
+                theSQL = [[NSMutableString alloc]initWithFormat:@"SELECT NSFKEY FROM NSFValues WHERE %@", [expression description]];
+            } else {
+                theSQL = [[NSMutableString alloc]initWithFormat:@"SELECT DISTINCT (NSFKEY) FROM NSFValues WHERE %@", [expression description]];
+            }
+            
+            if ((count > 1) && (i < count-1)) {
+                [theSQL appendString:@" AND NSFKEY IN ("];
+                [parentheses appendString:@")"];
+            }
+            
+            [sqlComponents addObject:theSQL];
         }
-        
-        [sqlComponents addObject:theSQL];
     }
     
     if ([parentheses length] > 0)

--- a/Tests/UnitTests/NanoStore/NanoStoreExpressionTests.m
+++ b/Tests/UnitTests/NanoStore/NanoStoreExpressionTests.m
@@ -83,6 +83,25 @@
     }
 }
 
+- (void)testEmptyExpressions
+{
+    NSFNanoStore *nanoStore = [NSFNanoStore createAndOpenStoreWithType:NSFMemoryStoreType path:nil error:nil];
+    [nanoStore removeAllObjectsFromStoreAndReturnError:nil];
+    [nanoStore addObjectsFromArray:[NSArray arrayWithObject:[NSFNanoObject nanoObjectWithDictionary:[NSDictionary dictionaryWithObjectsAndKeys:@"hello", @"name", nil]]] error:nil];
+    [nanoStore addObjectsFromArray:[NSArray arrayWithObject:[NSFNanoObject nanoObjectWithDictionary:[NSDictionary dictionaryWithObjectsAndKeys:@"world", @"name", nil]]] error:nil];
+
+    NSFNanoSearch *search = [NSFNanoSearch searchWithStore:nanoStore];
+    [search setExpressions:[NSArray array]];
+    
+    NSDictionary *searchResults = [search searchObjectsWithReturnType:NSFReturnObjects error:nil];
+    STAssertTrue ([searchResults count] == 2, @"Expected to find two objects.");
+    
+    searchResults = [search searchObjectsWithReturnType:NSFReturnKeys error:nil];
+    STAssertTrue ([searchResults count] == 2, @"Expected to find two objects.");
+    
+    [nanoStore closeWithError:nil];
+}
+
 - (void)testOnePredicateOneExpressionEqualTo
 {
     NSFNanoStore *nanoStore = [NSFNanoStore createAndOpenStoreWithType:NSFMemoryStoreType path:nil error:nil];


### PR DESCRIPTION
When i create search using expressions array, i found that if the array is empty, the SQL generated will return no result:

``` sql
SELECT DISTINCT (NSFKey),NSFPlist,NSFObjectClass FROM NSFKeys WHERE (NSFObjectClass = 'User') AND NSFKey IN ()
```

This pull request fix that and return all results with following SQL:

``` sql
SELECT DISTINCT (NSFKey),NSFPlist,NSFObjectClass FROM NSFKeys WHERE (NSFObjectClass = 'User') AND NSFKey IN (SELECT NSFKEY FROM NSFValues)
```
