### PR TITLE
add support for NSNULL type and NSKeyedArchiver/NSKeyedUnarchiver

### DIFF
--- a/Classes/Advanced/NSFNanoEngine.m
+++ b/Classes/Advanced/NSFNanoEngine.m
@@ -602,21 +602,35 @@ static NSSet    *__NSFPSharedNanoStoreEngineDatatypes = nil;
                     NSString *column = [[NSString alloc]initWithUTF8String:columnUTF8];
 
                     // Sanity check: some queries return NULL, which would cause a crash below.
-                    char *valueUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, columnIndex);
-                    NSString *value = nil;
-                    if (NULL != valueUTF8) {
-                        value = [[NSString alloc]initWithUTF8String:valueUTF8];
-                    } else {
-                        value = [[NSNull null]description];
+                    if ([column isEqualToString:@"NSFKeys.NSFPlist"]) {
+                        //NSFPlist is a blob
+                        NSData *dictBinData = [[NSData alloc] initWithBytes:sqlite3_column_blob(theSQLiteStatement, columnIndex) length: sqlite3_column_bytes(theSQLiteStatement, 1)];
+                        
+                        // Obtain the array to collect the values. If the array doesn't exist, create it.
+                        NSMutableArray *values = [info objectForKey:column];
+                        if (nil == values) {
+                            values = [NSMutableArray new];
+                        }
+                        [values addObject:dictBinData];
+                        [info setObject:values forKey:column];
+                    }else {
+                        char *valueUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, columnIndex);
+                        NSString *value = nil;
+                        if (NULL != valueUTF8) {
+                            value = [[NSString alloc]initWithUTF8String:valueUTF8];
+                        } else {
+                            value = [[NSNull null]description];
+                        }
+                        
+                        // Obtain the array to collect the values. If the array doesn't exist, create it.
+                        NSMutableArray *values = [info objectForKey:column];
+                        if (nil == values) {
+                            values = [NSMutableArray new];
+                        }
+                        [values addObject:value];
+                        [info setObject:values forKey:column];
                     }
-                    
-                    // Obtain the array to collect the values. If the array doesn't exist, create it.
-                    NSMutableArray *values = [info objectForKey:column];
-                    if (nil == values) {
-                        values = [NSMutableArray new];
-                    }
-                    [values addObject:value];
-                    [info setObject:values forKey:column];
+
                     
                     // Let's cleanup. This will keep the memory footprint low...
                 }

--- a/Classes/Public/NSFNanoGlobals.h
+++ b/Classes/Public/NSFNanoGlobals.h
@@ -71,7 +71,9 @@ typedef enum {
     /** * Used to store NSDate elements in the format <i>yyyy-MM-dd HH:mm:ss:SSS</i>. Its string equivalent is <b>TEXT</b>. */
     NSFNanoTypeDate,
     /** * Used to store NSNumber elements. Its string equivalent is <b>REAL</b>. */
-    NSFNanoTypeNumber
+    NSFNanoTypeNumber,
+    /** * Used to store NSNull elements. Its string equivalent is <b>NULL</b>. */
+    NSFNanoTypeNULL
 } NSFNanoDatatype;
 
 /** * Returns the name of a NSFNanoDatatype datatype as a string. */

--- a/Classes/Public/NSFNanoGlobals.m
+++ b/Classes/Public/NSFNanoGlobals.m
@@ -49,6 +49,7 @@ NSString * NSFStringFromNanoDataType (NSFNanoDatatype aNanoDatatype)
         case NSFNanoTypeDate: value = @"TEXT"; break;
         case NSFNanoTypeNumber: value = @"REAL"; break;
         case NSFNanoTypeRowUID: value = @"INTEGER"; break;
+        case NSFNanoTypeNULL: value = @"NULL"; break;
     }
     
     return value;
@@ -63,6 +64,7 @@ NSFNanoDatatype NSFNanoDatatypeFromString (NSString *aNanoDatatype)
     else if ([aNanoDatatype isEqualToString:@"TEXT"]) value = NSFNanoTypeDate;
     else if ([aNanoDatatype isEqualToString:@"REAL"]) value = NSFNanoTypeNumber;
     else if ([aNanoDatatype isEqualToString:@"INTEGER"]) value = NSFNanoTypeRowUID;
+    else if ([aNanoDatatype isEqualToString:@"NULL"]) value = NSFNanoTypeNULL;
 
     return value;
 }

--- a/Classes/Public/NSFNanoSearch.m
+++ b/Classes/Public/NSFNanoSearch.m
@@ -322,21 +322,25 @@
             default:
                 while (SQLITE_ROW == sqlite3_step (theSQLiteStatement)) {
                     char *keyUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, 0);
-                    char *dictXMLUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, 1);
+                    //char *dictXMLUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, 1);
+                    NSData *dictBinData = [[NSData alloc] initWithBytes:sqlite3_column_blob(theSQLiteStatement, 1) length: sqlite3_column_bytes(theSQLiteStatement, 1)];
+
                     char *objectClassUTF8 = (char *)sqlite3_column_text (theSQLiteStatement, 2);
                     
                     // Sanity check: some queries return NULL, which would a crash below.
                     // Since these are values that are NanoStore's resposibility, they should *never* be NULL. Log it for posterity.
-                    if ((NULL == keyUTF8) || (NULL == dictXMLUTF8) || (NULL == objectClassUTF8)) {
-                        NSLog(@"*** Warning! These values are NanoStore's resposibility and should *never* be NULL: keyUTF8 (%s) - dictXMLUTF8 (%s) - objectClassUTF8 (%s)", keyUTF8, dictXMLUTF8, objectClassUTF8);
+                    if ((NULL == keyUTF8) || (dictBinData == nil)/*(NULL == dictXMLUTF8)*/ || (NULL == objectClassUTF8)) {
+                        NSLog(@"*** Warning! These values are NanoStore's resposibility and should *never* be NULL: keyUTF8 (%s) - dictXMLUTF8 (\%s) - objectClassUTF8 (%s)", keyUTF8, /*dictXMLUTF8,*/ objectClassUTF8);
                         continue;
                     }
                     
                     NSString *keyValue = [[NSString alloc]initWithUTF8String:keyUTF8];
-                    NSString *dictXML = [[NSString alloc]initWithUTF8String:dictXMLUTF8];
+                    //NSString *dictXML = [[NSString alloc]initWithUTF8String:dictXMLUTF8];
                     NSString *objectClass = [[NSString alloc]initWithUTF8String:objectClassUTF8];
                     
-                    NSDictionary *info = [NSFNanoEngine _plistToDictionary:dictXML];
+                    //NSDictionary *info = [NSFNanoEngine _plistToDictionary:dictXML];
+                    NSDictionary *info = [NSKeyedUnarchiver unarchiveObjectWithData:dictBinData];
+                    
                     if (nil == info) {
                         continue;
                     }
@@ -459,7 +463,8 @@
                 
             for (i = 0; i < count; i++) {
                 @autoreleasepool {
-                    NSDictionary *info = [NSFNanoEngine _plistToDictionary:[resultsObjects objectAtIndex:i]];
+                    NSDictionary *info = [NSKeyedUnarchiver unarchiveObjectWithData:[resultsObjects objectAtIndex:i]];
+                    //NSDictionary *info = [NSFNanoEngine _plistToDictionary:[resultsObjects objectAtIndex:i]];
                     if (nil != info) {
                         NSString *keyValue = [resultsKeys objectAtIndex:i];
                         


### PR DESCRIPTION
Hi Tito Ciuro,

I have been trying to use nanostore to build an offline cache for a restful web server that talks JSON.
Nanostore worked very good but it was lacking support for NSNull.
As you can see a NSFNanoTypeNULL was created and NSPropertyListSerialization was replaced by NSKeyedArchiver/NSKeyedUnarchiver.

This new functionality can be activate/deactivated use the following macro
# define USEKEYARCHIVER 1 (support for NSNull is on) or  0 (the traditional NSPropertyList support )

And for my domain the changes resulted in a small performance increase too :-)
Hope this can help  and please do no hesitate to contact me for any question
