### PR TITLE
Add NanoStore.podspec to the project

### DIFF
--- a/Classes/Public/NSFNanoStore.h
+++ b/Classes/Public/NSFNanoStore.h
@@ -70,6 +70,7 @@
 #import "NSFNanoGlobals.h"
 
 @class NSFNanoEngine, NSFNanoResult, NSFNanoBag, NSFNanoSortDescriptor;
+@protocol NSFNanoObjectProtocol;
 
 @interface NSFNanoStore : NSObject
 

--- a/Classes/Public/NSFNanoStore.h
+++ b/Classes/Public/NSFNanoStore.h
@@ -67,6 +67,8 @@
 
 #import <sqlite3.h>
 
+#import "NSFNanoGlobals.h"
+
 @class NSFNanoEngine, NSFNanoResult, NSFNanoBag, NSFNanoSortDescriptor;
 
 @interface NSFNanoStore : NSObject

--- a/NanoStore.podspec
+++ b/NanoStore.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name          = 'NanoStore'
+  s.version       = '2.8.0'
+  s.license       = 'BSD'
+  s.summary       = 'NanoStore is an open source, lightweight schema-less local key-value document store written in Objective-C for Mac OS X and iOS.'
+  s.homepage      = 'https://github.com/tciuro/NanoStore'
+  s.authors       = { 'Tito Ciuro' => 'tciuro@mac.com' }
+  s.source        = { :git => 'https://github.com/tciuro/NanoStore.git', :tag => s.version.to_s }
+  s.source_files  = 'Classes/**/*.{h,m}'
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.8'
+  
+  s.library       = 'sqlite3'
+  s.requires_arc  = true
+end


### PR DESCRIPTION
Hi there. I was wondering why the podspec for CocoaPods wasn't part of this repo. In my opinion it would help getting started with NanoStore (and keeping it up to date). If there is a good reason not to include it, please excuse my PR, I couldn't find a discussion about it in the issue list.

I used @siuying's base version ([2.7.7](https://github.com/CocoaPods/Specs/blob/master/NanoStore/2.7.7/NanoStore.podspec)) for the podspec, only the version number is higher (2.8.0).

The two extra commits (3feecc2, 826c488) fix the pod to compile when added to an iOS project. The Mac unit tests still pass on my end.
![image](https://f.cloud.github.com/assets/218289/2060436/2d9cb2cc-8c18-11e3-9679-5a1bf43bfcb2.png)

Thanks for considering.
