### PR TITLE
Add keyed subscript accessor

### DIFF
--- a/Classes/Public/NSFNanoObject.h
+++ b/Classes/Public/NSFNanoObject.h
@@ -261,6 +261,7 @@
  */
 
 - (void)setObject:(id)anObject forKey:(NSString *)aKey;
+- (void)setObject:(id)anObject forKeyedSubscript:(NSString *)aKey;
 
 /** * Returns the value associated with a given key.
  * @param aKey the key for value. Must not be nil.
@@ -269,6 +270,7 @@
  */
 
 - (id)objectForKey:(NSString *)aKey;
+- (id)objectForKeyedSubscript:(NSString *)aKey;
 
 /** * Removes a given key and its associated value from the NanoObject.
  * @param aKey the key to remove. Must not be nil.

--- a/Classes/Public/NSFNanoObject.m
+++ b/Classes/Public/NSFNanoObject.m
@@ -140,9 +140,19 @@
     _hasUnsavedChanges = YES;
 }
 
+- (void)setObject:(id)anObject forKeyedSubscript:(NSString *)aKey
+{
+    [self setObject:anObject forKey:aKey];
+}
+
 - (id)objectForKey:(NSString *)aKey
 {
     return [_info objectForKey:aKey];
+}
+
+- (id)objectForKeyedSubscript:(NSString *)aKey
+{
+    return [self objectForKey:aKey];
 }
 
 - (void)removeObjectForKey:(NSString *)aKey

--- a/Tests/UnitTests/NanoStore/NanoStoreObjectTests.m
+++ b/Tests/UnitTests/NanoStore/NanoStoreObjectTests.m
@@ -141,6 +141,17 @@
     STAssertTrue ((nil != info) && ([info count] == 1) && ([[info objectForKey:@"foo"]isEqualToString:@"bar"]), @"Expected setObject:forKey: to work.");
 }
 
+- (void)testObjectWithSubscriptAccessor
+{
+    NSFNanoObject *object = [NSFNanoObject nanoObject];
+    object[@"foo"] = @"bar";
+    NSDictionary *info = object.info;
+    
+    STAssertTrue ((nil != info) && ([info count] == 1) && ([[info objectForKey:@"foo"]isEqualToString:@"bar"]), @"Expected setObject:forKey: to work.");    
+
+    STAssertEqualObjects(object[@"foo"], @"bar", @"Can access with keyed subscript");
+}
+
 - (void)testObjectRemoveObjectForKeyNonEmptyObject
 {
     NSFNanoObject *object = [NSFNanoObject nanoObjectWithDictionary:_defaultTestInfo];


### PR DESCRIPTION
Did you consider to add keyed subscript accessor with NanoObject?
I think it is convenient.

```objective-c
NSFNanoObject *object = [NSFNanoObject nanoObject];
object[@"foo"] = @"bar";
id value = object[@"foo"];
```
